### PR TITLE
feat(common): make CrudDao save() return persisted entity

### DIFF
--- a/S3.3-escape-room/src/main/java/org/s3team/common/dao/CrudDao.java
+++ b/S3.3-escape-room/src/main/java/org/s3team/common/dao/CrudDao.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface CrudDao<T> {
 
-    void save(T entity);
+    T save(T entity);
 
     Optional<T> findById(Id<T> id);
 


### PR DESCRIPTION
This change allows DAOs to return the fully persisted entity including auto-generated IDs.